### PR TITLE
Hardcoding heroku URL to services

### DIFF
--- a/app/scripts/services/expense.js
+++ b/app/scripts/services/expense.js
@@ -2,7 +2,7 @@
 
 angular.module('quarak')
   .factory('Expense', function Expense($resource) {
-    var Expense = $resource('/api/projects/:projectId/expenses/:id', {
+    var Expense = $resource('http://quarak.herokuapp.com/api/projects/:projectId/expenses/:id', {
         id: '@id',
         projectId: '@projectId'
       }, {

--- a/app/scripts/services/project.js
+++ b/app/scripts/services/project.js
@@ -3,7 +3,7 @@
 angular.module('quarak')
   .factory('Project', ['$resource', function($resource) {
     var Project = $resource(
-      '/api/projects/:id',
+      'http://quarak.herokuapp.com/api/projects/:id',
       { id: '@id' },
       { update: {
         method: 'PUT' }

--- a/app/scripts/services/session.js
+++ b/app/scripts/services/session.js
@@ -21,7 +21,7 @@ angular.module('quarak')
         var defer = $q.defer();
 
         $http
-          .post('/api/sign_in', user)
+          .post('http://quarak.herokuapp.com/api/sign_in', user)
           .success(function (data, status, headers, config) {
             $window.sessionStorage.token = data.token;
             service.requestCurrentUser().then(function currentUser(user) {
@@ -42,7 +42,7 @@ angular.module('quarak')
         var defer = $q.defer();
         if (!service.signedIn) {
           $http
-            .get('/api/profile')
+            .get('http://quarak.herokuapp.com/api/profile')
             .success(function profile(user) {
               service.signedIn = true;
               service.currentUser = user;

--- a/app/scripts/services/settlement.js
+++ b/app/scripts/services/settlement.js
@@ -2,7 +2,7 @@
 
 angular.module('quarak')
   .factory('Settlement', function Settlement($resource) {
-    var Settlement = $resource('/api/projects/:projectId/settlements/:id', {
+    var Settlement = $resource('http://quarak.herokuapp.com/api/projects/:projectId/settlements/:id', {
         id: '@id',
         projectId: '@projectId'
       }, {


### PR DESCRIPTION
@damianfarina Dami, de que manera podemos hacer que la URL de la API sea configurable según el entorno?. Lo ideal sería cargarla a partir de alguna variable de ambiente, con defaults cómodos para development como `localhost:3000` o simplemente urls relativas (que empiecen con `/api/bla-bal`). 

En `quarak-server` instalé un middleware que implementa CORS, y lo configure para que permita requests de cualquier origin. Así que si levantas este branch de `quarak-web` le va a pegar a la API deployada en heroku. 
